### PR TITLE
Friday Night Porting

### DIFF
--- a/code/datums/objective/individual_objective/command.dm
+++ b/code/datums/objective/individual_objective/command.dm
@@ -41,3 +41,18 @@
 	UnregisterSignal(linked, COMSIG_SHIP_STILL)
 	..()
 */
+
+/datum/individual_objective/bluecross
+	name = "Mantal Pice"
+	req_department = list(DEPARTMENT_COMMAND)
+	var/obj/item/target
+
+/datum/individual_objective/bluecross/proc/pick_bluecross_candidates()
+	var/obj/randomcatcher/CATCH = new /obj/randomcatcher
+	return CATCH.get_item(/obj/random/oddity_guns)
+
+/datum/individual_objective/bluecross/assign()
+	..()
+	target = pick_bluecross_candidates()
+	desc = "Sometimes having a tricket is just nice. Acquire a [target.name] if possable..."
+	RegisterSignal(mind_holder, COMSING_HUMAN_EQUITP, .proc/task_completed)

--- a/code/datums/objective/individual_objective/common.dm
+++ b/code/datums/objective/individual_objective/common.dm
@@ -101,7 +101,7 @@
 	if(completed) return
 	UnregisterSignal(mind_holder, COMSIG_CARBON_HAPPY)
 	..()
-
+/*
 /datum/individual_objective/gift
 	name = "Odd Gift"
 	desc = "You feel a need to leave a mark in other people lives. Ensure that someone will level up with oddity that you touched or preferably gave them."
@@ -160,7 +160,7 @@
 	if(completed) return
 	UnregisterSignal(target, COMSIG_HUMAN_HEALTH)
 	..()
-/*
+
 /datum/individual_objective/helper
 	name = "Helping Hand"
 	units_requested = 15 MINUTES
@@ -236,7 +236,7 @@
 	if(completed) return
 	UnregisterSignal(mind_holder, COMSIG_MOB_LIFE)
 	..()
-
+/*
 /datum/individual_objective/greed
 	name = "Greed"
 	units_requested = 10 MINUTES
@@ -275,7 +275,7 @@
 	if(completed) return
 	UnregisterSignal(mind_holder, COMSIG_MOB_LIFE)
 	..()
-
+*/
 /datum/individual_objective/collenction
 	name = "Collection"
 	var/obj/item/target
@@ -302,7 +302,7 @@
 	if(completed) return
 	UnregisterSignal(mind_holder, COMSING_HUMAN_EQUITP)
 	..()
-/* //This one is buggy as shit and few people know how it works, removing it until it can be fixed. -Kaz
+
 /datum/individual_objective/economy
 	name = "Business"
 	var/datum/money_account/target
@@ -327,9 +327,10 @@
 			valids_targets += H.mind.initial_account
 	valids_targets -= owner.initial_account
 	target = pick(valids_targets)
-	units_requested = rand(500, 1000)
+	units_requested = rand(1500, 3000) //500-1000 was to little lets make this harder
 	desc = "The money must always flow but you must also prevent fees from ruining you.  \
-			Make a back transfer from you personal account for amount of [units_requested][CREDITS]."
+			Make a back transfer from you personal account for amount of [units_requested][CREDITS].\
+			Back transfer meaning adding the [units_requested][CREDITS] must be added to your account"
 	RegisterSignal(owner.initial_account, COMSIG_TRANSATION, .proc/task_completed)
 
 /datum/individual_objective/economy/task_completed(datum/money_account/S, datum/money_account/T, amount)
@@ -340,4 +341,41 @@
 	if(completed) return
 	UnregisterSignal(owner.initial_account, COMSIG_TRANSATION)
 	..()
-*/
+
+//Back transfer but removes credits form the game to make people want to sell things or make money
+/datum/individual_objective/bills
+	name = "Bills To Pay"
+	var/datum/money_account/target
+
+/datum/individual_objective/bills/can_assign(mob/living/L)
+	if(!..())
+		return FALSE
+	if(!L.mind.initial_account)
+		return FALSE
+	var/list/valids_targets = list()
+	for(var/mob/living/carbon/human/H in ((GLOB.player_list & GLOB.living_mob_list & GLOB.human_mob_list) - L))
+		if(H.mind && H.mind.initial_account)
+			valids_targets += H.mind.initial_account
+	valids_targets -= L.mind.initial_account
+	return valids_targets.len
+
+/datum/individual_objective/bills/assign()
+	..()
+	var/list/valids_targets = list()
+	for(var/mob/living/T in GLOB.human_mob_list)
+		if(T.mind && T.mind.initial_account)
+			valids_targets += T.mind.initial_account
+	valids_targets -= owner.initial_account
+	target = pick(valids_targets)
+	units_requested = rand(1000, 2000) //Housing water and power, shouldnt be cheap
+	desc = "The bills must be payed or you could be without housing, or other normal luxuries, provide this account number: \"[target.account_number]\" with the sum of [units_requested][CREDITS]..."
+	RegisterSignal(owner.initial_account, COMSIG_TRANSATION, .proc/task_completed)
+
+/datum/individual_objective/bills/task_completed(datum/money_account/S, datum/money_account/T, amount)
+	if(S == owner.initial_account && T == target)
+		..(amount)
+
+/datum/individual_objective/bills/completed()
+	if(completed) return
+	UnregisterSignal(owner.initial_account, COMSIG_TRANSATION)
+	..()

--- a/code/datums/objective/individual_objective/moebius.dm
+++ b/code/datums/objective/individual_objective/moebius.dm
@@ -103,7 +103,7 @@
 	if(completed) return
 	UnregisterSignal(mind_holder, COMSING_AUTOPSY)
 	..()
-
+/*
 /datum/individual_objective/more_research
 	name = "Progress no matter the cost."
 	req_department = list(DEPARTMENT_SCIENCE)
@@ -130,7 +130,7 @@
 	if(completed) return
 	UnregisterSignal(mind_holder, COMSING_DESTRUCTIVE_ANALIZER)
 	..()
-
+*/
 /datum/individual_objective/damage
 	name = "A Different Perspective"
 	req_department = list(DEPARTMENT_SCIENCE, DEPARTMENT_MEDICAL)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -114,6 +114,13 @@
 	desc = "They seem to pulse slightly with an inner life"
 	icon_state = "eggs"
 	var/amount_grown = 0
+	var/spiderlings_lower = 3
+	var/spiderlings_upper = 6
+
+/obj/effect/spider/eggcluster/minor
+	amount_grown = 20
+	spiderlings_lower = 2
+	spiderlings_upper = 4
 
 /obj/effect/spider/eggcluster/New(var/location, var/atom/parent)
 	pixel_x = rand(3,-3)
@@ -133,7 +140,7 @@
 /obj/effect/spider/eggcluster/Process()
 	amount_grown += rand(0,2)
 	if(amount_grown >= 100)
-		var/num = rand(1,3)
+		var/num = rand(spiderlings_lower,spiderlings_upper)
 		var/obj/item/organ/external/O = null
 		if(istype(loc, /obj/item/organ/external))
 			O = loc

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -9,16 +9,16 @@
 		return 0
 
 	src.traumatic_shock = 			\
-	1	* src.getOxyLoss() + 		\
+	1.5	* src.getOxyLoss() + 		\
 	0.5	* src.getToxLoss() + 		\
-	1	* src.getFireLoss() + 		\
+	0.8	* src.getFireLoss() + 		\
 	1	* src.getBruteLoss() + 		\
-	1.7	* src.getCloneLoss() + 		\
-	2	* src.halloss + 			\
+	1.8	* src.getCloneLoss() + 		\
+	1.5	* src.halloss + 			\
 	-1	* src.analgesic
 
 	if(src.slurring)
-		src.traumatic_shock -= 20
+		src.traumatic_shock -= 30 //being drunk or on some types of drugs will allow you to withstand more
 
 	if(src.traumatic_shock < 0)
 		src.traumatic_shock = 0
@@ -30,7 +30,7 @@
 	..()
 	for(var/obj/item/organ/external/organ in organs)
 		if(organ && (organ.is_broken() || organ.open))
-			traumatic_shock += 30
+			traumatic_shock += 20 //Broken bones are painful but not something to criple someone in pain
 
 	return traumatic_shock
 

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
@@ -46,6 +46,6 @@
 	colony_friend = FALSE
 	friendly_to_colony = FALSE
 
-/mob/living/carbon/superior_animal/giant_spider/New(location, atom/parent)
-	..()
+/mob/living/carbon/superior_animal/giant_spider/New(var/location, var/atom/parent)
 	get_light_and_color(parent)
+	..()

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
@@ -22,8 +22,8 @@
 	emote_see = list("chitters.","rubs its legs.","trails webs through its hairs.","screeches.")
 	var/web_activity = 30
 	armor = list(melee = 0, bullet = 0, energy = 0, bomb = 5, bio = 10, rad = 25, agony = 0)
-
-
+	var/egg_inject_chance = 0 //AHAHAHAHAHAHAHAAHAHAH, no
+	life_cycles_before_sleep = 3000 //We need more time to eat and web
 
 /mob/living/carbon/superior_animal/giant_spider/nurse/midwife
 	name = "midwife spider"
@@ -35,6 +35,7 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 15
 	poison_per_bite = 4
+	egg_inject_chance = 5 //Yes
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/spider/midwife
 
 /mob/living/carbon/superior_animal/giant_spider/nurse/carrier
@@ -43,6 +44,7 @@
 	icon_state = "carrier"
 	icon_living = "carrier"
 	deathmessage = "splits open! Several wriggling spiders crawl from its gore!"
+	egg_inject_chance = 2 //maybe...
 	var/has_made_spiderlings = FALSE
 
 /mob/living/carbon/superior_animal/giant_spider/nurse/carrier/death(var/gibbed,var/message = deathmessage)
@@ -73,7 +75,6 @@
 	web_activity = 90
 	armor = list(melee = 15, bullet = 10, energy = 0, bomb = 5, bio = 10, rad = 25, agony = 0)
 
-
 /mob/living/carbon/superior_animal/giant_spider/nurse/recluse
 	name = "recluse spider"
 	desc = "Furry and brown, it makes you shudder to look at it. This one has brilliant green eyes and light brown skin."
@@ -86,6 +87,7 @@
 	melee_damage_upper = 5
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/spider/recluse
 	meat_amount = 2
+	egg_inject_chance = 15 //Defiently
 	//Giving the recluse its own special meat that has zombie powder. Reducing the amount of meat made since this is some hard stuff and the recluse is easy to kill.
 	poison_type = "zombiepowder"
 
@@ -104,6 +106,7 @@
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/spider/queen
 	meat_amount = 3
 	flash_resistances = 5 //For balance against are speedy fello
+	egg_inject_chance = 10 //Likely
 	//Giving the queen her own meat type which contains MENACE.
 	mob_size = MOB_LARGE
 	armor = list(melee = 15, bullet = 10, energy = 0, bomb = 5, bio = 10, rad = 25, agony = 0)
@@ -114,14 +117,16 @@
 	pixel_y = null
 
 /mob/living/carbon/superior_animal/giant_spider/nurse/attemptAttackOnTarget()
-	var/target = ..()
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
-		if(prob(poison_per_bite))
+	..()
+	if(ishuman(target_mob))
+		var/mob/living/carbon/human/H = target_mob
+		if(prob(egg_inject_chance))
 			var/obj/item/organ/external/O = safepick(H.organs)
 			if(O && !BP_IS_ROBOTIC(O))
-				var/eggs = new /obj/effect/spider/eggcluster(O, src)
-				O.implants += eggs
+				src.visible_message(SPAN_DANGER("[src] injects something into the [O] of [H]!"))
+				var/obj/effect/spider/eggcluster/minor/S = new()
+				S.loc = O
+				O.implants += S
 
 /mob/living/carbon/superior_animal/giant_spider/nurse/proc/GiveUp(var/C)
 	spawn(100)

--- a/code/modules/mob/living/carbon/superior_animal/human/human.dm
+++ b/code/modules/mob/living/carbon/superior_animal/human/human.dm
@@ -7,6 +7,7 @@
 	viewRange = 8
 	speak_chance = 5
 	turns_per_move = 5
+	randpixel = 0
 
 	attack_sound = 'sound/weapons/slice.ogg'
 

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/roachling.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/roachling.dm
@@ -17,6 +17,7 @@
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/roachmeat
 	meat_amount = 1
 	eating_time = 1200 //Takes longer for small roaches to eat
+	life_cycles_before_sleep = 800 //We need more time to eat
 	probability_egg_laying = 0
 	var/amount_grown = 0
 	var/big_boss = FALSE

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -489,37 +489,6 @@
 /datum/reagent/other/luminol/touch_mob(mob/living/L)
 	L.reveal_blood()
 
-
-/datum/reagent/other/aranecolmin
-	name = "Aranecolmin"
-	id = "aranecolmin"
-	description = "Weak antitoxin used by warrior spiders. Speeds up metabolism immensely."
-	taste_description = "sludge"
-	reagent_state = LIQUID
-	color = "#acc107"
-	overdose = REAGENTS_OVERDOSE
-	addiction_chance = 10
-	nerve_system_accumulations = 5
-
-/datum/reagent/other/aranecolmin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
-	M.add_chemical_effect(CE_ANTITOX, 0.3)
-	if(M.bloodstr)
-		for(var/current in M.bloodstr.reagent_list)
-			var/datum/reagent/toxin/pararein/R = current
-			if(istype(R))
-				R.metabolism = initial(R.metabolism) * 3
-				break
-
-/datum/reagent/other/aranecolmin/on_mob_delete(mob/living/carbon/M)
-	..()
-	if(istype(M))
-		if(M.bloodstr)
-			for(var/current in M.bloodstr.reagent_list)
-				var/datum/reagent/toxin/pararein/R = current
-				if(istype(R))
-					R.metabolism = initial(R.metabolism)
-					break
-
 /datum/reagent/other/arectine
 	name = "Arectine"
 	id = "arectine"

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -470,16 +470,47 @@
 	reagent_state = LIQUID
 	color = "#a37d9c"
 	overdose = REAGENTS_OVERDOSE/3
-	addiction_chance = 0.1
-	nerve_system_accumulations = 5
+	addiction_chance = 0.01 //Will STILL likely always be addicting
+	nerve_system_accumulations = 10
 	strength = 0.1
 	heating_point = 523
 	heating_products = list("toxin")
 
 /datum/reagent/toxin/pararein/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	..()
-	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_BASIC, STIM_TIME, "pararein")
-	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_BASIC, STIM_TIME, "pararein")
+	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "pararein")
+	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "pararein")
+	M.stats.addTempStat(STAT_COG, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "pararein")
+
+/datum/reagent/toxin/aranecolmin
+	name = "Aranecolmin"
+	id = "aranecolmin"
+	description = "Weak antitoxin used by warrior spiders. Speeds up metabolism immensely."
+	taste_description = "sludge"
+	reagent_state = LIQUID
+	color = "#acc107"
+	overdose = REAGENTS_OVERDOSE
+	addiction_chance = 10
+	nerve_system_accumulations = 5
+
+/datum/reagent/toxin/aranecolmin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	M.add_chemical_effect(CE_ANTITOX, 0.3)
+	if(M.bloodstr)
+		for(var/current in M.bloodstr.reagent_list)
+			var/datum/reagent/toxin/pararein/R = current
+			if(istype(R))
+				R.metabolism = initial(R.metabolism) * 3
+				break
+
+/datum/reagent/toxin/aranecolmin/on_mob_delete(mob/living/carbon/M)
+	..()
+	if(istype(M))
+		if(M.bloodstr)
+			for(var/current in M.bloodstr.reagent_list)
+				var/datum/reagent/toxin/pararein/R = current
+				if(istype(R))
+					R.metabolism = initial(R.metabolism)
+					break
 
 /datum/reagent/toxin/diplopterum
 	name = "Diplopterum"


### PR DESCRIPTION
Updates Zavod to Sojourn 29-Oct-21
CL:
By Kazkin:
-Fixed a long running and minor visual bug where human mobs like excelsior slaves and void wolves would have randomized pixel off set.

By Trilby
-Removes all personal objectives to kill faction items or collect them
-Removes odd gift objective do to lag
-Removes Protector do to it being dumb bad and horrable
-Adds 2 new personal goals
-Re-adds back transfer and better explains how to do it

-Broken bones now deal 10 less shock
-O2 damage deals more pain
-Fire damage deals less pain
-Halloss (mostly tasers and disarms) deals sightly less
-Cloneloss deals less
-Slurring like being drunk or on heavy drugs heal more shock

By Alliostra
-Nurse spiders can inject people with spider eggs sometimes and spiderling amout in eggs
By Trilby
-Makes spiders not fall asleep 3x longers so they can eat/web bodies more
-increases roachling awake timer as well to allow it to eat more bodies


