### PR TITLE
Space suits can now be modded.

### DIFF
--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -88,6 +88,7 @@
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.9
 	species_restricted = list("exclude")
+	tool_qualities = list(QUALITY_ARMOR = 100)
 	equip_delay = 4 SECONDS
 	var/list/supporting_limbs //If not-null, automatically splints breaks. Checked when removing the suit.
 

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -227,7 +227,7 @@
 		to_chat(user, SPAN_WARNING("You cannot modify \the [src] while it is being worn."))
 		return
 
-	if(istype(W,/obj/item/tool/screwdriver))
+	if(W.has_quality(QUALITY_BOLT_TURNING))
 		if(boots || tank || helmet)
 			var/choice = input("What component would you like to remove?") as null|anything in list(boots,tank,helmet)
 			if(!choice) return


### PR DESCRIPTION
## About The Pull Request
Gives space suits `QUALITY_ARMOR = 100`, as space helmets already have it. This allows spacesuits to accept armor platings.

## Changelog
:cl:
balance: spacesuits can now be armor plated
tweak: voidsuit mods are now removed via wrench, to not interfere with toolmods
/:cl:
